### PR TITLE
game.py: swap sin and cos functions in the rocket movements method

### DIFF
--- a/server/game.py
+++ b/server/game.py
@@ -28,8 +28,8 @@ class Rocket:
         self.angle = angle
 
     def move(self):
-        self.x = self.x + math.sin(math.radians(self.angle))
-        self.y = self.y + math.cos(math.radians(self.angle))
+        self.x = self.x + math.cos(math.radians(self.angle))
+        self.y = self.y + math.sin(math.radians(self.angle))
         print "Moving rocket to ", self.x, " ", self.y
         
     def isOut(self):


### PR DESCRIPTION
in game.py, in the Rocket.move() method, the sin() and cos() functions should be swapped. Otherwise using trigonometric functions in the clients/bots to track rockets becomes a nightmare, as compared to the unit circle:
- the degrees measurements increase when going clockwise (instead of counterclockwise)
- the degrees have a rotation offset of 90 degrees
